### PR TITLE
add nx-stylelint

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@
 
 - [stylelint-find-new-rules](https://github.com/Donov4n/stylelint-find-new-rules) - Find stylelint rules that are not configured in your stylelint config.
 - [stylelint-tape](https://www.npmjs.com/package/stylelint-tape) - A stylelint rule tester using tape.
+- [nx-stylelint](https://github.com/Phillip9587/nx-stylelint) - Plugin to use stylelint in an [Nx](https://github.com/nrwl/nx) workspace.
 
 ## Tutorials
 


### PR DESCRIPTION
Adds:

[nx-stylelint](https://github.com/Phillip9587/nx-stylelint) - Plugin to use stylelint in an [Nx](https://github.com/nrwl/nx) workspace.

