### PR TITLE
Remove `sh-waqar/stylelint-declaration-use-variable`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@
 - [stylelint-order](https://github.com/hudochenkov/stylelint-order) - A collection of order related linting rules for stylelint.
 - [stylelint-scss](https://github.com/kristerkari/stylelint-scss) - A collection of SCSS specific linting rules for stylelint.
 - [stylelint-selector-bem-pattern](https://github.com/davidtheclark/stylelint-selector-bem-pattern) - A stylelint plugin that incorporates [postcss-bem-linter](https://github.com/postcss/postcss-bem-linter).
-- [stylelint-declaration-use-variable](https://github.com/sh-waqar/stylelint-declaration-use-variable) - A stylelint plugin to check the use of variables on declaration in (less/scss/css).
 - [stylelint-no-unsupported-browser-features](https://github.com/ismay/stylelint-no-unsupported-browser-features) - A stylelint plugin that checks if the CSS you're using is supported by the browsers you're targeting.
 - [stylelint-a11y](https://github.com/YozhikM/stylelint-a11y) - A stylelint plugin to check the accessibility of your CSS for users.
 - [stylelint-high-performance-animation](https://github.com/kristerkari/stylelint-high-performance-animation) - A stylelint rule for preventing the use of low performance animation and transition properties.


### PR DESCRIPTION
Plugin is no longer maintained:
> https://github.com/sh-waqar/stylelint-declaration-use-variable#stylelint-declaration-use-variable
> ⚠️ This project is not actively maintained. Please use stylelint-declaration-strict-value ⚠️

The recommended https://github.com/AndyOGo/stylelint-declaration-strict-value is already on stylelint-awesome, so awesome

<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

