### PR TITLE
Add stylelint-css-modules-no-global-scoped-selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@
 - [stylelint-z-index-value-constraint](https://github.com/kristerkari/stylelint-z-index-value-constraint) - Specify minimum and maximum constraint value for z-index.
 - [stylelint-plugin-stylus](https://github.com/ota-meshi/stylelint-plugin-stylus) - stylelint plugin for [Stylus](https://stylus-lang.com/).
 - [stylelint-css-modules](https://github.com/juanca/stylelint-css-modules) - A set of rules to enforce CSS modules architecture.
+- [stylelint-css-modules-no-global-scoped-selector](https://github.com/lmichelin/stylelint-css-modules-no-global-scoped-selector) - Stylelint rule for CSS modules to prevent usage of global-scoped selectors.
 - [stylelint-no-restricted-syntax](https://github.com/niksy/stylelint-no-restricted-syntax) - Stylelint rule to disallow specified syntax, similar to ESLint `no-restricted-syntax`.
 - [stylelint-no-unresolved-module](https://github.com/niksy/stylelint-no-unresolved-module) - Ensures that module (import-like or `url`) can be resolved to a module on the file system.
 - [stylelint-max-lines](https://github.com/dkrnl/stylelint-max-lines) - Limit the count of a lines.


### PR DESCRIPTION
Add [stylelint-css-modules-no-global-scoped-selector](https://github.com/lmichelin/stylelint-css-modules-no-global-scoped-selector) - Stylelint rule for CSS modules to prevent usage of global-scoped selectors.