### PR TITLE
Add `hudochenkov/order`, Stylelint's Recommended and Standard for SCSS, and Prettier to the list of configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 - [stylelint-standard](https://github.com/stylelint/stylelint-config-standard) - The standard shareable config for Stylelint (extends the recommended one).
 - [stylelint-standard-scss](https://github.com/stylelint-scss/stylelint-config-standard-scss) - Same as above, when using SCSS.
 - [Prettier](https://github.com/prettier/stylelint-config-prettier) - Turns off all rules that are unnecessary when using Prettier.
+- [Prettier-scss](https://github.com/prettier/stylelint-config-prettier-scss) - Same as above, when using SCSS.
 - [GitHub](https://github.com/primer/stylelint-config-primer) - Sharable Stylelint config used by GitHub's CSS.
 - [rational-order](https://github.com/constverum/stylelint-config-rational-order) - Stylelint config that sorts related property declarations by grouping together in the rational order.
 - [hudochenkov/order](https://github.com/hudochenkov/stylelint-config-hudochenkov/blob/master/order.js) - Another config that sorts property declarations logically.

--- a/README.md
+++ b/README.md
@@ -15,12 +15,13 @@
 
 ## Configs
 
+- [stylelint-recommended](https://github.com/stylelint/stylelint-config-recommended) and [stylelint-recommended-scss](https://github.com/stylelint-scss/stylelint-config-recommended-scss) - The recommended shareable config for Stylelint.
+- [stylelint-standard](https://github.com/stylelint/stylelint-config-standard) and [stylelint-standard-scss](https://github.com/stylelint-scss/stylelint-config-standard-scss) - The standard shareable config for Stylelint (extends the recommended one).
+- [Prettier](https://github.com/prettier/stylelint-config-prettier) - Turns off all rules that are unnecessary when using Prettier.
 - [GitHub](https://github.com/primer/stylelint-config-primer) - Sharable Stylelint config used by GitHub's CSS.
 - [rational-order](https://github.com/constverum/stylelint-config-rational-order) - Stylelint config that sorts related property declarations by grouping together in the rational order.
 - [hudochenkov/order](https://github.com/hudochenkov/stylelint-config-hudochenkov/blob/master/order.js) - Another config that sorts property declarations logically.
 - [strict-scss](https://github.com/wemake-services/wemake-frontend-styleguide/tree/master/packages/stylelint-config-scss) - Strict shareable config for Stylelint and SCSS.
-- [stylelint-recommended](https://github.com/stylelint/stylelint-config-recommended) - The recommended shareable config for Stylelint.
-- [stylelint-standard](https://github.com/stylelint/stylelint-config-standard) - The standard shareable config for Stylelint.
 - [Wikimedia](https://github.com/wikimedia/stylelint-config-wikimedia) - Wikimedia CSS Coding Standards shareable config for Stylelint.
 - [WordPress](https://github.com/WordPress-Coding-Standards/stylelint-config-wordpress) - WordPress CSS Coding Standards shareable config for Stylelint.
 - [stylelint-config-sass-guidelines](https://github.com/bjankord/stylelint-config-sass-guidelines) - A Stylelint config based on [https://sass-guidelin.es/](https://sass-guidelin.es/).

--- a/README.md
+++ b/README.md
@@ -15,8 +15,10 @@
 
 ## Configs
 
-- [stylelint-recommended](https://github.com/stylelint/stylelint-config-recommended) and [stylelint-recommended-scss](https://github.com/stylelint-scss/stylelint-config-recommended-scss) - The recommended shareable config for Stylelint.
-- [stylelint-standard](https://github.com/stylelint/stylelint-config-standard) and [stylelint-standard-scss](https://github.com/stylelint-scss/stylelint-config-standard-scss) - The standard shareable config for Stylelint (extends the recommended one).
+- [stylelint-recommended](https://github.com/stylelint/stylelint-config-recommended) - The recommended shareable config for Stylelint.
+- [stylelint-recommended-scss](https://github.com/stylelint-scss/stylelint-config-recommended-scss) - Same as above, when using SCSS.
+- [stylelint-standard](https://github.com/stylelint/stylelint-config-standard) - The standard shareable config for Stylelint (extends the recommended one).
+- [stylelint-standard-scss](https://github.com/stylelint-scss/stylelint-config-standard-scss) - Same as above, when using SCSS.
 - [Prettier](https://github.com/prettier/stylelint-config-prettier) - Turns off all rules that are unnecessary when using Prettier.
 - [GitHub](https://github.com/primer/stylelint-config-primer) - Sharable Stylelint config used by GitHub's CSS.
 - [rational-order](https://github.com/constverum/stylelint-config-rational-order) - Stylelint config that sorts related property declarations by grouping together in the rational order.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 
 - [GitHub](https://github.com/primer/stylelint-config-primer) - Sharable Stylelint config used by GitHub's CSS.
 - [rational-order](https://github.com/constverum/stylelint-config-rational-order) - Stylelint config that sorts related property declarations by grouping together in the rational order.
+- [hudochenkov/order](https://github.com/hudochenkov/stylelint-config-hudochenkov/blob/master/order.js) - Another config that sorts property declarations logically.
 - [strict-scss](https://github.com/wemake-services/wemake-frontend-styleguide/tree/master/packages/stylelint-config-scss) - Strict shareable config for Stylelint and SCSS.
 - [stylelint-recommended](https://github.com/stylelint/stylelint-config-recommended) - The recommended shareable config for Stylelint.
 - [stylelint-standard](https://github.com/stylelint/stylelint-config-standard) - The standard shareable config for Stylelint.


### PR DESCRIPTION
`hudochenkov/order` is a great config in my opinion, made by the creator of the `stylelint-order` plugin.

I also added Stylelint's Recommended and Standard configs for SCSS, as well as Prettier's configs.

<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
