### PR TITLE
Add Postcss-Angular to List of Custom Syntaxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
 
 ## Custom syntaxes
 
+- [postcss-angular](https://www.npmjs.com/package/postcss-angular) - Angular Components.
 - [postcss-html](https://www.npmjs.com/package/postcss-html) - HTML, including Vue SFC.
 - [postcss-less](https://www.npmjs.com/package/postcss-less) - Less.
 - [postcss-linaria](https://www.npmjs.com/package/@linaria/postcss-linaria) - Linaria.
@@ -51,7 +52,6 @@
 - [postcss-scss](https://www.npmjs.com/package/postcss-scss) - SCSS.
 - [postcss-styled-components](https://www.npmjs.com/package/postcss-styled-components) - Styled-components.
 - [postcss-styled-syntax](https://www.npmjs.com/package/postcss-styled-syntax) - Template literals.
-- [postcss-angular](https://www.npmjs.com/package/postcss-angular) - Angular Components
 
 ## Editor integrations
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@
 - [postcss-scss](https://www.npmjs.com/package/postcss-scss) - SCSS.
 - [postcss-styled-components](https://www.npmjs.com/package/postcss-styled-components) - Styled-components.
 - [postcss-styled-syntax](https://www.npmjs.com/package/postcss-styled-syntax) - Template literals.
+- [postcss-angular](https://www.npmjs.com/package/postcss-angular) - Angular Components
 
 ## Editor integrations
 


### PR DESCRIPTION
I have created this custom syntax and I think it belongs on this list.
