### PR TITLE
Adds Stylelint-Plugin-Logical-CSS to Plugins List

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@
 - [stylelint-order](https://github.com/hudochenkov/stylelint-order) - Order things like properties.
 - [stylelint-plugin-defensive-css](https://github.com/yuschick/stylelint-plugin-defensive-css) - A Stylelint plugin for enforcing defensive CSS best practices.
 - [stylelint-plugin-ecss](https://github.com/tyankatsu0105/stylelint-plugin-ecss) - Enforce Enduring CSS architecture.
+- [stylelint-plugin-logical-css](https://github.com/yuschick/stylelint-plugin-logical-css) - A Stylelint plugin to enforce logical CSS properties, values and units.
 - [stylelint-react-native](https://github.com/kristerkari/stylelint-react-native) - Enforce React Native rules (Pack).
 - [stylelint-rem-over-px](https://github.com/a-tokyo/stylelint-rem-over-px) - Enforce `rem` units over `px` units.
 - [stylelint-rscss](https://github.com/rstacruz/stylelint-rscss) - Enforce RSCSS conventions (Pack).
@@ -118,7 +119,7 @@
 - [stylelint-use-nesting](https://github.com/csstools/stylelint-use-nesting) - Enforce nesting when it is possible.
 - [stylelint-value-no-exposed-custom-properties](https://github.com/denisraslov/stylelint-value-no-exposed-custom-properties) - Disallow usage of exposed custom properties.
 - [stylelint-value-no-unknown-custom-properties](https://github.com/csstools/stylelint-value-no-unknown-custom-properties) - Disallow unknown custom properties.
-- [stylelint-plugin-logical-css](https://github.com/yuschick/stylelint-plugin-logical-css) - A Stylelint plugin to enforce logical CSS properties, values and units.
+- [stylelint-z-index-value-constraint](https://github.com/kristerkari/stylelint-z-index-value-constraint) - Specify minimum and maximum constraint value for z-index.
 
 ## Task runners
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@
 - [stylelint-use-nesting](https://github.com/csstools/stylelint-use-nesting) - Enforce nesting when it is possible.
 - [stylelint-value-no-exposed-custom-properties](https://github.com/denisraslov/stylelint-value-no-exposed-custom-properties) - Disallow usage of exposed custom properties.
 - [stylelint-value-no-unknown-custom-properties](https://github.com/csstools/stylelint-value-no-unknown-custom-properties) - Disallow unknown custom properties.
-- [stylelint-z-index-value-constraint](https://github.com/kristerkari/stylelint-z-index-value-constraint) - Specify minimum and maximum constraint value for z-index.
+- [stylelint-plugin-logical-css](https://github.com/yuschick/stylelint-plugin-logical-css) - A Stylelint plugin to enforce logical CSS properties, values and units.
 
 ## Task runners
 


### PR DESCRIPTION
Adds the `stylelint-plugin-logical-css` plugin to the Plugins list.

**Duplicate Concern**
While this plugin is like the `stylelint-use-logical-spec` plugin, this one adds support for even more physical properties and values, and adds support for enforcing logical sizing units as well.

https://github.com/yuschick/stylelint-plugin-logical-css