### PR TITLE
Prepare for website

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Awesome Stylelint [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 
-[<img src="https://raw.githubusercontent.com/stylelint/stylelint/master/identity/stylelint-icon-white-512.png" width="160" align="right" alt="stylelint">](https://stylelint.io/)
+<a href="https://stylelint.io/"><img src="https://raw.githubusercontent.com/stylelint/stylelint/main/identity/stylelint-icon-white-512.png" width="160" align="right" alt="Stylelint" /></a>
 
 > A list of awesome Stylelint configs, plugins, integrations etc.
 

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "name": "awesome-stylelint",
+  "version": "0.0.0",
+  "private": true,
   "scripts": {
     "test": "awesome-lint"
   },


### PR DESCRIPTION
This change prepares for publishing this Awesome Stylelint on our website (https://stylelint.io/).

- Add some fields to `package.json` to fetch Awesome Stylelint via npm.
- Fix a `<img>` link in README to prevent a Markdown processing error.

<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref https://github.com/stylelint/stylelint.io/issues/370

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
