### PR TITLE
Rename `stylelint-plugin-require-baseline` to `stylelint-plugin-use-baseline`

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ A list of awesome Stylelint configs, plugins, integrations etc.
 
 - [stylelint-no-browser-hacks](https://www.npmjs.com/package/stylelint-no-browser-hacks) - Disallow browser hacks that are irrelevant to the browsers you are targeting.
 - [stylelint-no-unsupported-browser-features](https://www.npmjs.com/package/stylelint-no-unsupported-browser-features) - Disallow CSS that is unsupported by the browsers you're targeting.
-- [stylelint-plugin-require-baseline](https://www.npmjs.com/package/stylelint-plugin-require-baseline) - Disallow CSS features not in Baseline.
+- [stylelint-plugin-use-baseline](https://www.npmjs.com/package/stylelint-plugin-use-baseline) - Disallow CSS features not in Baseline.
 
 ### Colors
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See: https://github.com/ryo-manba/stylelint-plugin-use-baseline/issues/6

> Is there anything in the PR that needs further explanation?

I renamed the plugin to match the rule in eslint/css.
See: https://github.com/eslint/css/issues/96
