### PR TITLE
Add `@apostrophecms/stylelint-no-mixed-decls` plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ A list of awesome Stylelint configs, plugins, integrations etc.
 
 - [stylelint-scss](https://www.npmjs.com/package/stylelint-scss) - Enforce SCSS-specific conventions (Pack).
 - [stylelint-stylus](https://www.npmjs.com/package/stylelint-stylus) - Enforce Stylus-specific conventions.
+- [@apostrophecms/stylelint-no-mixed-decls](https://www.npmjs.com/package/@apostrophecms/stylelint-no-mixed-decls) - Enfore Sass's [mixed-decls](https://sass-lang.com/documentation/breaking-changes/mixed-decls/) rule.
 
 ### Performance
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, submit a new plugin to prevent Sass's `mixed-decls` warnings.

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.